### PR TITLE
Pins base image to tag opencv-4.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jjanzic/docker-python3-opencv
+FROM jjanzic/docker-python3-opencv:opencv-4.0.0
 
 COPY ./requirements.txt /app/requirements.txt
 WORKDIR /app


### PR DESCRIPTION
The latest image of jjanzic/docker-python3-opencv:opencv-4.0.0 is not compatible
with torch==1.6.0.

Fixes #2.